### PR TITLE
Caching when downloading via URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 *.iml
 .gradle
 /local.properties
-/.idea/workspace.xml
-/.idea/libraries
+/.idea
+/.idea
 .DS_Store
 /build
 /captures

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .gradle
 /local.properties
 /.idea
-/.idea
 .DS_Store
 /build
 /captures

--- a/README.md
+++ b/README.md
@@ -84,3 +84,24 @@ Setting the gif programmatically:
 ```java
 mGifView.setGifResource("asset:gif1");
 ```
+
+## File Caching
+
+GIFView is caching all GIF files it downloads when being provided with an URL to an image. If an
+InputStream is used, no caching is performed.
+
+The caching works as follows:
+
+The GIFView initializes the GIFCache class with the URL provided by the caller. The GIFCache
+class now checks for the existence of the sub-directory "GIFView" within the app's own
+cache-directory. If that is not found, it will be created and the GIF-image will be downloaded
+into it. If it does exist, the existence of the GIF-image is checked, and if found, the
+cached-version will be provided. If the image is not found, it will be downloaded and then the
+cached file will be used.
+
+In order to clear the cached files programmatically, GIFCache offers the possibility to retrieve
+the folder as a java.io.File object by calling the static method getCacheSubDir():
+
+```java
+File GIFCache.getCacheSubDir(Context context);
+```

--- a/app/src/main/java/com/whygraphics/gifview/gif/GIFCache.java
+++ b/app/src/main/java/com/whygraphics/gifview/gif/GIFCache.java
@@ -16,7 +16,12 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 /**
- * The GIFCache class takes care of downloading and caching of GIF files.
+ * <p>The GIFCache class takes care of downloading and caching of GIF files.</p>
+ *
+ * <p>All downloaded files are stored in the implementing app's own cache-directory, under a
+ * sub-directory called "GIFView". The exact path can be retrieved using the method
+ * {@link #getCacheSubDir()}, which will return a {@link File} object representing that
+ * directory.</p>
  *
  */
 class GIFCache {

--- a/app/src/main/java/com/whygraphics/gifview/gif/GIFCache.java
+++ b/app/src/main/java/com/whygraphics/gifview/gif/GIFCache.java
@@ -18,9 +18,6 @@ import java.security.NoSuchAlgorithmException;
 /**
  * The GIFCache class takes care of downloading and caching of GIF files.
  *
- * @author seifert
- * @version 1.0
- * @since 1.0
  */
 class GIFCache {
     private static final String HASH_MD5 = "MD5";

--- a/app/src/main/java/com/whygraphics/gifview/gif/GIFCache.java
+++ b/app/src/main/java/com/whygraphics/gifview/gif/GIFCache.java
@@ -20,11 +20,14 @@ import java.security.NoSuchAlgorithmException;
  *
  */
 class GIFCache {
+
+    private static final String CACHE_SUB_DIR = File.separator + "GIFView";
     private static final String HASH_MD5 = "MD5";
     private static final int BUFFER_SIZE = 65536;
 
     private final String url;
     private final File cachedGIF;
+    private final File cacheSubDir;
 
     /**
      * <p>Creates a new GIFCache object for GIF images defined by the given {@code url}.</p>
@@ -36,7 +39,11 @@ class GIFCache {
         this.url = url;
 
         try {
-            cachedGIF = new File(context.getCacheDir() + File.separator + bytesToHex(computeHash(url)));
+            cacheSubDir = new File(context.getCacheDir() + CACHE_SUB_DIR);
+            if(!cacheSubDir.exists()) {
+                cacheSubDir.mkdirs();
+            }
+            cachedGIF = new File(cacheSubDir.getAbsolutePath() + File.separator + bytesToHex(computeHash(url)));
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException(e);
         } catch (UnsupportedEncodingException e) {
@@ -142,5 +149,15 @@ class GIFCache {
             hexChars[baseIndex + 1] = hexArray[value & 0x0F];
         }
         return new String(hexChars);
+    }
+
+    /**
+     * Returns a {@link File} object representing the directory within the app's cache-area under
+     * which this {@link GIFCache} object stores all cached files.
+     *
+     * @return THe {@link File} object representing the cache sub-directory.
+     */
+    public File getCacheSubDir() {
+        return cachedGIF.getParentFile();
     }
 }

--- a/app/src/main/java/com/whygraphics/gifview/gif/GIFCache.java
+++ b/app/src/main/java/com/whygraphics/gifview/gif/GIFCache.java
@@ -24,7 +24,7 @@ import java.security.NoSuchAlgorithmException;
  * directory.</p>
  *
  */
-class GIFCache {
+public class GIFCache {
 
     private static final String CACHE_SUB_DIR = File.separator + "GIFView";
     private static final String HASH_MD5 = "MD5";
@@ -32,7 +32,7 @@ class GIFCache {
 
     private final String url;
     private final File cachedGIF;
-    private final File cacheSubDir;
+    private static File cacheSubDir;
 
     /**
      * <p>Creates a new GIFCache object for GIF images defined by the given {@code url}.</p>
@@ -44,14 +44,13 @@ class GIFCache {
         this.url = url;
 
         try {
-            cacheSubDir = new File(context.getCacheDir() + CACHE_SUB_DIR);
-            if(!cacheSubDir.exists()) {
-                cacheSubDir.mkdirs();
+            if(!getCacheSubDir(context).exists()) {
+                if(!cacheSubDir.mkdirs()) {
+                    throw new IOException("Cannot create directory " + cacheSubDir.getAbsolutePath());
+                }
             }
             cachedGIF = new File(cacheSubDir.getAbsolutePath() + File.separator + bytesToHex(computeHash(url)));
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException(e);
-        } catch (UnsupportedEncodingException e) {
+        } catch (Exception e) {
             throw new IllegalStateException(e);
         }
     }
@@ -162,7 +161,10 @@ class GIFCache {
      *
      * @return THe {@link File} object representing the cache sub-directory.
      */
-    public File getCacheSubDir() {
-        return cachedGIF.getParentFile();
+    public static File getCacheSubDir(Context context) {
+        if(cacheSubDir == null) {
+            cacheSubDir = new File(context.getCacheDir() + CACHE_SUB_DIR);
+        }
+        return cacheSubDir;
     }
 }

--- a/app/src/main/java/com/whygraphics/gifview/gif/GIFCache.java
+++ b/app/src/main/java/com/whygraphics/gifview/gif/GIFCache.java
@@ -16,25 +16,30 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 /**
- * Takes care of downloading and caching of GIF files
+ * The GIFCache class takes care of downloading and caching of GIF files.
  *
  * @author seifert
  * @version 1.0
  * @since 1.0
  */
-public class GIFCache {
+class GIFCache {
     private static final String HASH_MD5 = "MD5";
     private static final int BUFFER_SIZE = 65536;
 
     private final String url;
     private final File cachedGIF;
 
-    public GIFCache(Context context, String url) {
+    /**
+     * <p>Creates a new GIFCache object for GIF images defined by the given {@code url}.</p>
+     *
+     * @param context The {@link Context} is required to access the app's cache directory
+     * @param url The URL that points to the GIF image.
+     */
+    GIFCache(Context context, String url) {
         this.url = url;
 
         try {
-            cachedGIF = new File(context.getCacheDir() + File.separator + bytesToHex(computeHash
-                    (url)));
+            cachedGIF = new File(context.getCacheDir() + File.separator + bytesToHex(computeHash(url)));
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException(e);
         } catch (UnsupportedEncodingException e) {
@@ -42,13 +47,27 @@ public class GIFCache {
         }
     }
 
-    public InputStream getInputStream() throws IOException {
+    /**
+     * <p>Returns the InputStream to the cached GIF image file.</p>
+     * <p>If the GIF is not cached, it will be downloded automatically. The InputStream returned
+     * is always the InputStream to the cached file.</p>
+     *
+     * @return The InputStream to the cached file.
+     *
+     * @throws IOException Thrown if an I/O error occurs.
+     */
+    InputStream getInputStream() throws IOException {
         if(!cachedGIF.exists()) {
             downloadGIF();
         }
         return openCachedGIFInputStream();
     }
 
+    /**
+     * <p>Download the GIF image into the cache.</p>
+     *
+     * @throws IOException Thrown in case of an I/O Error.
+     */
     private void downloadGIF() throws IOException {
         InputStream bis = null;
         BufferedOutputStream bos = null;
@@ -79,10 +98,29 @@ public class GIFCache {
         }
     }
 
+    /**
+     * <p>Returns a freshly opened InputStream for the cached file.</p>
+     *
+     * @return A freshly opened {@link InputStream} for the cached GIF file.
+     * @throws FileNotFoundException Thrown in case the GIF file cannot be found.
+     */
     private InputStream openCachedGIFInputStream() throws FileNotFoundException {
         return new BufferedInputStream(new FileInputStream(cachedGIF));
     }
 
+    /**
+     * <p>Compute an MD5 hash for the given {@code text}.</p>
+     *
+     * <p>Please note that the two exceptions thrown by this method are theoretically possible,
+     * but very unlikely in most cases.</p>
+     *
+     * @param text The text to calculate the hash from.
+     * @return The MD5 hash of the given {@code text} as a hexadecimal {@link String}.
+     *
+     * @throws NoSuchAlgorithmException Thrown in case the MF5 algorithm cannot be found
+     * @throws UnsupportedEncodingException Thrown if the encoding of {@code text} is not
+     * supported.
+     */
     private static byte[] computeHash(String text) throws NoSuchAlgorithmException, UnsupportedEncodingException {
         MessageDigest md = MessageDigest.getInstance(HASH_MD5);
         md.update(text.getBytes("UTF-8"), 0, text.length());

--- a/app/src/main/java/com/whygraphics/gifview/gif/GIFCache.java
+++ b/app/src/main/java/com/whygraphics/gifview/gif/GIFCache.java
@@ -33,7 +33,8 @@ public class GIFCache {
         this.url = url;
 
         try {
-            cachedGIF = new File(context.getCacheDir() + File.pathSeparator + bytesToHex(computeHash(url)));
+            cachedGIF = new File(context.getCacheDir() + File.separator + bytesToHex(computeHash
+                    (url)));
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException(e);
         } catch (UnsupportedEncodingException e) {
@@ -49,20 +50,23 @@ public class GIFCache {
     }
 
     private void downloadGIF() throws IOException {
-        BufferedInputStream bis = null;
+        InputStream bis = null;
         BufferedOutputStream bos = null;
 
         try {
-            bis = new BufferedInputStream((InputStream) new URL(url).getContent());
+            bis = (InputStream) new URL(url).getContent();
             bos = new BufferedOutputStream(new FileOutputStream(cachedGIF));
 
             byte[] bytes = new byte[BUFFER_SIZE];
             int bytesRead;
-
+            boolean hasBytes;
             do {
                 bytesRead = bis.read(bytes);
-                bos.write(bytes, 0, bytesRead);
-            } while (bytesRead > 0);
+                hasBytes = bytesRead != -1;
+                if(hasBytes) {
+                    bos.write(bytes, 0, bytesRead);
+                }
+            } while (hasBytes);
 
             bos.flush();
         } finally {

--- a/app/src/main/java/com/whygraphics/gifview/gif/GIFCache.java
+++ b/app/src/main/java/com/whygraphics/gifview/gif/GIFCache.java
@@ -1,0 +1,107 @@
+package com.whygraphics.gifview.gif;
+
+import android.content.Context;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Takes care of downloading and caching of GIF files
+ *
+ * @author seifert
+ * @version 1.0
+ * @since 1.0
+ */
+public class GIFCache {
+    private static final String HASH_MD5 = "MD5";
+    private static final int BUFFER_SIZE = 65536;
+
+    private final String url;
+    private final File cachedGIF;
+
+    public GIFCache(Context context, String url) {
+        this.url = url;
+
+        try {
+            cachedGIF = new File(context.getCacheDir() + File.pathSeparator + bytesToHex(computeHash(url)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public InputStream getInputStream() throws IOException {
+        if(!cachedGIF.exists()) {
+            downloadGIF();
+        }
+        return openCachedGIFInputStream();
+    }
+
+    private void downloadGIF() throws IOException {
+        BufferedInputStream bis = null;
+        BufferedOutputStream bos = null;
+
+        try {
+            bis = new BufferedInputStream((InputStream) new URL(url).getContent());
+            bos = new BufferedOutputStream(new FileOutputStream(cachedGIF));
+
+            byte[] bytes = new byte[BUFFER_SIZE];
+            int bytesRead;
+
+            do {
+                bytesRead = bis.read(bytes);
+                bos.write(bytes, 0, bytesRead);
+            } while (bytesRead > 0);
+
+            bos.flush();
+        } finally {
+            if(bis != null) {
+                bis.close();
+            }
+            if(bos != null) {
+                bos.close();
+            }
+        }
+    }
+
+    private InputStream openCachedGIFInputStream() throws FileNotFoundException {
+        return new BufferedInputStream(new FileInputStream(cachedGIF));
+    }
+
+    private static byte[] computeHash(String text) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+        MessageDigest md = MessageDigest.getInstance(HASH_MD5);
+        md.update(text.getBytes("UTF-8"), 0, text.length());
+        return md.digest();
+    }
+
+    /**
+     * Convert an array of arbitrary bytes into a String of hexadecimal number-pairs with each pair representing on byte
+     * of the array.
+     *
+     * @param bytes the array to convert into hexadecimal string
+     * @return the String containing the hexadecimal representation of the array
+     */
+    private static String bytesToHex(byte[] bytes) {
+        final char[] hexArray = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                'A', 'B', 'C', 'D', 'E', 'F'};
+        char[] hexChars = new char[bytes.length << 1];
+        for (int i = 0; i < bytes.length; i++) {
+            int value = bytes[i] & 0xFF;
+            int baseIndex = i << 1;
+            hexChars[baseIndex] = hexArray[value >>> 4];
+            hexChars[baseIndex + 1] = hexArray[value & 0x0F];
+        }
+        return new String(hexChars);
+    }
+}

--- a/app/src/main/java/com/whygraphics/gifview/gif/GIFView.java
+++ b/app/src/main/java/com/whygraphics/gifview/gif/GIFView.java
@@ -324,9 +324,8 @@ public class GIFView extends ImageView {
                 protected InputStream getGifInputStream(String string) throws Exception {
                     final int URL_START_INDEX = RESOURCE_PREFIX_URL.length();
                     String url = string.substring(URL_START_INDEX);
-
-                    // gets the input stream from the url
-                    return (InputStream) new URL(url).getContent();
+                    GIFCache cache = new GIFCache(getContext(), url);
+                    return cache.getInputStream();
                 }
 
             }.execute(string);

--- a/app/src/main/java/com/whygraphics/gifview/gif/GIFView.java
+++ b/app/src/main/java/com/whygraphics/gifview/gif/GIFView.java
@@ -735,6 +735,17 @@ public class GIFView extends ImageView {
     }
 
     /**
+     * <p>Returns the {@link File} object to the cache subdirectory, in which the cache stores
+     * all downloaded GIF image files.</p>
+     *
+     * @param context The application context for accessing the app's cache directory
+     * @return The {@link File} object representing GIFView's cache directory.
+     */
+    public static File getCacheSubDir(Context context) {
+        return GIFCache.getCacheSubDir(context);
+    }
+
+    /**
      * Interface definition for callbacks to be invoked when setting a gif.
      */
     public interface OnSettingGifListener {


### PR DESCRIPTION
When GIFView is requested to download the GIF images via URL, caching that image falls into the responsibility of the View. It doesn't, when the caller provides an InputStream, but if the caller only provides an URL, the GIFView should do the caching.
Therefore, I have created this PR, with a class called GIFCache that hooks into the loading process when loading from an URL, and downloads the GIF image into the app's cache area, and opens an InputStream from there, passing that on, as before was done with the URL-inputstream.